### PR TITLE
EMR deployment: add S3 buckets

### DIFF
--- a/accumulator/infra/README.md
+++ b/accumulator/infra/README.md
@@ -1,1 +1,14 @@
-TODO: all terraform and other provisioning code should go here
+# Bootstrappping a EMR Cluster
+
+This terraform deployment is fully automated. However, due to some AWS limitations, you'll have to bootstrap a few things before booting up your first EMR cluster.
+
+Note: you only need to run this once per AWS account.
+
+You'll first need to install the AWS CLI tool. Set your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` AWS account env variables. Then, run:
+
+```
+aws configure
+aws emr create-default-roles
+```
+
+This will create the default AWS EMR roles. This deployment depends upon them.


### PR DESCRIPTION
```
commit 6a0da59f2dfcd94b08b20aee76927325d823606c (HEAD -> nin/EMR-v2, origin/nin/EMR-v2)

    EMR: revise IAM policies
    
    We used to define custom IAM policies for the EMR cluster. While it
    kept the project self-contained (the EMR-specifc generic IAM policies
    sadly need a AWS cli call to be bootstrapped), it would have been more
    tricky to maitain on the long run to keep the alignment with the EMR
    cluster.
    
    We roll back to use the default EMR policies for the cluster. We add
    some custom policies of top of the default ones to get access to the
    S3 buckets.

commit 111c04c24205e2524638c20925f60df116003ea3
    EMR deployment: add S3 buckets
    
    We'll need 3 S3 buckets for this deployment:
    
    1. A bucket containing the incoming data the EMR cluster
       needs to process.
    2. A bucket containing the results processed by the EMR cluster.
    3. A bucket containing various cluster metadata such as the boostrap
       script, map/reduce script, etc.
    
    We create a 2 days expiration policy on the input and output buckets
    to clear the transcient data.

```