### PR TITLE
Deployment: create ECR Docker registry

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,4 +56,18 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
+      - name: ECR Registry login
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: "us-east-1"
+      - name: Push to ECR registry
+        uses: docker/build-push-action@v2
+        with:
+          context: accumulator/infra/hadoop-single-node-cluster
+          tags: public.ecr.aws/y6u2m5w7/zk-rollup-docker-registry:latest
+          push: true
     # TODO: upload map.js & reduce.js

--- a/accumulator/infra/bootstrap/README.md
+++ b/accumulator/infra/bootstrap/README.md
@@ -1,0 +1,7 @@
+# Meta-Infra
+
+This repository contains the terraform code to spin up all the meta infra used by this project.
+
+This meta infra contains:
+
+- A docker registry where the CI pushes the Sequencer Docker image.

--- a/accumulator/infra/bootstrap/main.tf
+++ b/accumulator/infra/bootstrap/main.tf
@@ -1,0 +1,113 @@
+variable "region" {
+  description = "AWS Deployment region."
+  default = "eu-central-1"
+}
+
+variable "project" {
+  description = "Project name exposed in AWS user tag"
+  default = "mina"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "mina-tf-state"
+    key = "tfstate-bootstrap"
+    region = "eu-central-1"
+  }
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.4"
+    }
+  }
+}
+
+# Note: the ECR API is only available through us-east-1.
+# See: https://github.com/aws/karpenter/issues/3015
+provider "aws" {
+  region = "us-east-1"
+  alias = "virginia"
+}
+
+data "aws_ecrpublic_authorization_token" "token" {
+  provider = aws.virginia
+}
+
+provider "aws" {
+  region = "${var.region}"
+}
+
+resource "aws_ecrpublic_repository" "zk_rollup" {
+  repository_name = "zk-rollup-docker-registry"
+  provider = aws.virginia
+
+  catalog_data {
+    about_text        = "Fast ZK Rollup Docker Registry"
+    architectures     = ["x86-64"]
+    operating_systems = ["Linux"]
+  }
+}
+
+data "aws_iam_user" "registry_user" {
+  user_name = "docker-registry-github"
+}
+
+resource "aws_iam_user_policy" "registry_access" {
+  name = "test"
+  user = data.aws_iam_user.registry_user.user_name
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ecr-public:*",
+          "sts:GetServiceBearerToken"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "zk_rollup_ecr_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [ "${data.aws_iam_user.registry_user.arn}" ]
+    }
+    actions = [
+      "ecr-public:*",
+      "sts:GetServiceBearerToken"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    principals {
+      type = "*"
+      identifiers = [ "*" ]
+    }
+    actions = [
+      "ecr-public:GetAuthorizationToken",
+      "sts:GetServiceBearerToken",
+      "ecr-public:BatchCheckLayerAvailability",
+      "ecr-public:GetRepositoryPolicy",
+      "ecr-public:DescribeRepositories",
+      "ecr-public:DescribeRegistries",
+      "ecr-public:DescribeImages",
+      "ecr-public:DescribeImageTags",
+      "ecr-public:GetRepositoryCatalogData",
+      "ecr-public:GetRegistryCatalogData"
+    ]
+  }
+}
+
+resource "aws_ecrpublic_repository_policy" "zk_rollup" {
+  provider = aws.virginia
+  repository_name = aws_ecrpublic_repository.zk_rollup.repository_name
+  policy = data.aws_iam_policy_document.zk_rollup_ecr_policy.json
+}


### PR DESCRIPTION
We create a public ECR registry through a terraform deployment. We modify the CI script to push the artifact to the github actions cache and this new ECR registry.

Note: can't test that locally. I'll also have to merge this PR to get proper access to the AWS secret (PR don't have access to "new" secrets).