### PR TITLE
Infra: add Sequencer

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -3,7 +3,11 @@
 
 name: fast-zk-rollup-ci
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run_integration_tests:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Push to ECR registry
         uses: docker/build-push-action@v2
         with:
-          context: accumulator/infra/hadoop-single-node-cluster
+          context: sequencer
           tags: public.ecr.aws/y6u2m5w7/zk-rollup-docker-registry:latest
           push: true
     # TODO: upload map.js & reduce.js

--- a/accumulator/infra/README.md
+++ b/accumulator/infra/README.md
@@ -12,3 +12,7 @@ aws emr create-default-roles
 ```
 
 This will create the default AWS EMR roles. This deployment depends upon them.
+
+# Sequencer NixOS Configuration
+
+The sequencer is launched on a NixOS EC2 machine. This machine runs the Sequencer docker image through a systemd-managed podman service. This service is reverse-proxied by Nginx.

--- a/accumulator/infra/main.tf
+++ b/accumulator/infra/main.tf
@@ -128,7 +128,7 @@ resource "aws_s3_object" "emr_mapper" {
 # subnet. The routing table is pretty straightforward: a simple
 # non-NATed gateway.
 
-resource "aws_subnet" "public-1" {
+resource "aws_subnet" "public_1" {
   vpc_id = "${aws_vpc.main.id}"
   cidr_block = "10.0.0.0/24"
   map_public_ip_on_launch = "true"
@@ -158,7 +158,7 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "public-1"{
-  subnet_id = "${aws_subnet.public-1.id}"
+  subnet_id = "${aws_subnet.public_1.id}"
   route_table_id = "${aws_route_table.public.id}"
 }
 
@@ -169,7 +169,7 @@ resource "aws_route_table_association" "public-1"{
 # We're NAT-ing the egress through a gateway having a public eip.
 
 
-resource "aws_subnet" "private-1" {
+resource "aws_subnet" "private_1" {
   vpc_id = "${aws_vpc.main.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "${var.region}a"
@@ -187,13 +187,13 @@ resource "aws_eip" "nat_gateway" {
 
 resource "aws_nat_gateway" "main" {
   allocation_id = aws_eip.nat_gateway.id
-  subnet_id     = "${aws_subnet.public-1.id}"
+  subnet_id     = "${aws_subnet.public_1.id}"
   tags = {
     project = "${var.project}"
   }
 }
 
-resource "aws_route_table" "private-1" {
+resource "aws_route_table" "private_1" {
   vpc_id = "${aws_vpc.main.id}"
   route {
     cidr_block = "0.0.0.0/0"
@@ -205,9 +205,9 @@ resource "aws_route_table" "private-1" {
   }
 }
 
-resource "aws_route_table_association" "private-1"{
-  subnet_id = "${aws_subnet.private-1.id}"
-  route_table_id = "${aws_route_table.private-1.id}"
+resource "aws_route_table_association" "private_1"{
+  subnet_id = "${aws_subnet.private_1.id}"
+  route_table_id = "${aws_route_table.private_1.id}"
 }
 
 # EC2 Security Groups
@@ -328,7 +328,7 @@ resource "aws_emr_cluster" "accumulator" {
   applications = [ "Hadoop" ]
   service_role = "EMR_DefaultRole"
   ec2_attributes {
-    subnet_id                         = aws_subnet.private-1.id
+    subnet_id                         = aws_subnet.private_1.id
     additional_master_security_groups = "${aws_security_group.emr_master.id}"
     additional_slave_security_groups  = "${aws_security_group.emr_core.id}"
     instance_profile                  = aws_iam_instance_profile.emr_ec2.name
@@ -340,7 +340,7 @@ resource "aws_emr_cluster" "accumulator" {
   }
 
   core_instance_group {
-    instance_count = 2
+    instance_count = 1
     instance_type  = "m5a.xlarge"
     # TODO: set up autoscaling policy w/ spot instances.
   }
@@ -352,5 +352,69 @@ resource "aws_emr_cluster" "accumulator" {
   tags = {
     for-use-with-amazon-emr-managed-policies = true
     project = "mina"
+  }
+}
+
+
+# Sequencer EC2 Setup
+#####################
+
+data "aws_iam_policy_document" "sequencer_assume_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    actions = [
+      "sts:AssumeRole",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "sequencer_role_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "elasticmapreduce:AddJobFlowSteps",
+      "elasticmapreduce:AddTags",
+      "elasticmapreduce:CancelStep",
+      "elasticmapreduce:Describe*",
+      "elasticmapreduce:Get*",
+      "elasticmapreduce:List*",
+      "elasticmapreduce:RunJobFlow",
+      "elasticmapreduce:TerminateJobFlows",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "sequencer_role" {
+  name = "sequencer-role"
+  path = "/"
+  assume_role_policy = data.aws_iam_policy_document.sequencer_assume_role_policy.json
+  inline_policy {
+    name = "emr-access"
+    policy = data.aws_iam_policy_document.sequencer_role_policy.json
+  }
+}
+
+resource "aws_iam_instance_profile" "sequencer_emr_profile" {
+  name = "test_profile"
+  role = aws_iam_role.sequencer_role.name
+}
+
+resource "aws_instance" "Sequencer" {
+  ami = "ami-0d6ee9d5e1c985df6" # NixOS 23.05.426.afc48694f2a
+  subnet_id = aws_subnet.public_1.id
+  instance_type = "m5a.large"
+  user_data = file("./sequencer-nixos-config.nix")
+  iam_instance_profile = aws_iam_instance_profile.emr_ec2.name
+  vpc_security_group_ids = [ aws_security_group.sequencer.id ]
+  root_block_device {
+    volume_size = 15
+  }
+  tags = {
+    project = "${var.project}"
   }
 }

--- a/accumulator/infra/run-sequencer-test-vm.nix
+++ b/accumulator/infra/run-sequencer-test-vm.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import (
+  builtins.fetchTarball {
+    # Note: keep in sync with AMI image deployed on EC2!!!!!
+    url = "https://github.com/NixOS/nixpkgs/archive/aed4b19d312525ae7ca9bceb4e1efe3357d0e2eb.tar.gz";
+    sha256 = "sha256:1hxgxfa5a880xw1ni7xssg3zbkg3dl62w7qgiln636m80zaqma24";
+  }) { } }:
+
+let
+  testVmClosure = { ... }: {
+    imports = [ ./sequencer-nixos-config.nix ];
+    # Setting root password as empty to interactively debug the VM.
+    users.users.root.password = "";
+    users.mutableUsers = false;
+  };
+in (pkgs.nixos testVmClosure).vm

--- a/accumulator/infra/sequencer-nixos-config.nix
+++ b/accumulator/infra/sequencer-nixos-config.nix
@@ -1,0 +1,75 @@
+{ config, pkgs, ... }:
+
+{
+  imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
+  ec2.hvm = true;
+  security.sudo.wheelNeedsPassword = false;
+
+  users.users = {
+    ninjatrappeur = {
+      isNormalUser = true;
+      extraGroups = [ "wheel" ];
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHzd1XAB7Pc8Tplur5iV3llOXtvlHru8pLtQlbvHzmt1"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOE7oDtq+xt5RuvMigDZMeZQODFr5Otz6HCO8wnI80oo"
+      ];
+    };
+    ycryptx = {
+      isNormalUser = true;
+      extraGroups = [ "wheel" ];
+      openssh.authorizedKeys.keys = [
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCz7QlDRx7Vvra3XCfB4bWwFSxEgw81DHgeNrFTR5dxT/J29MfZhW+rjJXR4mVAvUGEBlNsGJ6EwBt65FqWxuWTGARoW2jBVMxqwqxldYLKHWcWTv8IdaYAQniKwfOX/3NaaQEw93HwHbb8aYjbBudR/UtwOgT0vDpuxUzPwIDRxea3Za64qV0H7s6PnfbC5DcC9fOX72fiGXuwMaZAUN8dIgI9mZcEn3yaWfwqYQ+Qcx6pDEWG73YLXJfoZ7UtSp+GF6lgOcTc7pw+NIoUcU/Pq+I0d7ECIEaRXv97U2R8lbgBRkR7NIBjxqSKHb3m5wfDvLQGrrn2Mg7zmGa8buyfeNaBfolEfa+c8R2fS8smvd7El3K/ogMeRJ3j5actRIP74UKqrgQd6nTJDkxD4F09bDHcke+PLlLkyURnatcRGH3J56sVTXRM5mRGuoFufBz8s6K+jS2Fmxirf97fJ61gq/M7w4LEDDX2gncrNeX+QmqGeWXV5wBFkvS2lxYGl88="
+      ];
+    };
+  };
+
+  services = {
+    openssh = {
+      enable = true;
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+      };
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    virtualHosts."localhost" = {
+      #addSSL = true;
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:8080";
+        extraConfig = ''
+          proxy_set_header Host $host;
+        '';
+      };
+    };
+  };
+
+  security.acme = {
+    defaults.email = "consulting@alternativebit.fr";
+    acceptTerms = true;
+  };
+
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+    22
+  ];
+
+  virtualisation = {
+    podman = {
+      enable = true;
+    };
+    oci-containers = {
+      backend = "podman";
+      containers = {
+        zk-rollup = {
+          image = "public.ecr.aws/y6u2m5w7/zk-rollup-docker-registry:latest";
+          autoStart = true;
+          extraOptions = [ "--expose=8080" ];
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
commit c427eaa1050d0dc98bf0be54b3addccd7b5a430f (HEAD -> nin/infra-sequencer, origin/nin/infra-sequencer, main)

    github action: run on main
    
    We were only running the github action on the PRs, preventing us to
    run the deployment job when a commit reaches main.

commit 54b897fb8ab9e78e58bdb953fd2185996a8364f5

    Infra: add Sequencer
    
    We create a EC2 machine running the fast-zk-rollup docker container.
    
    The NixOS EC2 machine loads this container through a systemd-managed
    podman runtime. The EC2 machine also runs a Nginx reverse proxy
    listening on 80. We'll add a TLS layer once we'll have a proper
    route53 setup for the domain name.
    
    We attach a policy to the EC2 machine allowing the services running on
    this machine to retrieve a temporary access token to control the EMR
    setup (ie. adding tasks, etc.).
