### PR TITLE
Infra: fix GRPC reverse proxy issue

### DIFF
--- a/accumulator/infra/sequencer-nixos-config.nix
+++ b/accumulator/infra/sequencer-nixos-config.nix
@@ -35,12 +35,12 @@
 
   services.nginx = {
     enable = true;
-    virtualHosts."localhost" = {
-      #addSSL = true;
+    virtualHosts."ec2-3-120-144-49.eu-central-1.compute.amazonaws.com" = {
+      addSSL = true;
+      enableACME = true;
       locations."/" = {
-        proxyPass = "http://127.0.0.1:8080";
         extraConfig = ''
-          proxy_set_header Host $host;
+          grpc_pass grpc://127.0.0.1:8080;
         '';
       };
     };


### PR DESCRIPTION
It seems like Nginx GRPC reverse proxy does not handle well plain text GRPC. It's not very chatty log-wise, the only way I managed to get rid of this issue is to create a self-signed certificate and serve the grpc reverse proxy through a TLS endpoint.

@ycryptx: to keep the AWS bill to an absolute minimum, I'm using the EIP domain name for now: it's free :) However, this domain is blacklisted by ACME, we can't issue a valid certificate for it. Meaning, we currently use a self-signed certificate.

If it's an issue for you, we can create a proper domain name and generate a valid certificate for it. If it's not, let's call it a day :)

From my desktop:

```
grpcurl --insecure "ec2-3-120-144-49.eu-central-1.compute.amazonaws.com:443" list
Failed to list services: server does not support the reflection API
```

(it indicates the setup works. We deployed the container in production mode, the reflection API is disabled)